### PR TITLE
Fix Mozilla issue with the use of querySelectorAll and forEach

### DIFF
--- a/src/amazon-autocomplete.js
+++ b/src/amazon-autocomplete.js
@@ -88,9 +88,12 @@
      * Hide widget when clicked outside the search field or the words container 
      */
     document.body.addEventListener('click', evt => {
-        if(!evt.amazonAutocompleteClicked)
-            document.querySelectorAll('.ac__container--hide-on-blur').forEach( elem => elem.style.display = 'none');
+        if(!evt.amazonAutocompleteClicked){
+            NodeList.prototype.forEach = Array.prototype.forEach; 
+            HTMLCollection.prototype.forEach = Array.prototype.forEach; // Because of https://bugzilla.mozilla.org/show_bug.cgi?id=14869
         
+            document.querySelectorAll('.ac__container--hide-on-blur').forEach( elem => elem.style.display = 'none');
+        }
     });
 
     //---------------------------------------------//


### PR DESCRIPTION
"Click out" was not working on Mozilla.